### PR TITLE
[ADD] 2156, 12026 JAVA solution

### DIFF
--- a/dynamic_programming_1/12026/Main.java
+++ b/dynamic_programming_1/12026/Main.java
@@ -1,0 +1,72 @@
+// Authored by : vswngjs
+// Co-authored by : -
+// Link : http://boj.kr/ed9212b6595d4e678366d326ab71c304
+import java.util.*;
+import java.io.*;
+public class Main {
+    public static void main(String [] args) {
+        FastReader rd = new FastReader();
+
+        int N = rd.nextInt();
+        String s = rd.nextLine();
+        int [] dp = new int[N];     // 필요한 에너지 양의 최솟값을 담는 배열 dp
+        Arrays.fill(dp, -1);    // dp 배열을 -1로 초기화하여 dp[i]가 -1이면 도착이 불가능한  칸임을 표현
+        // 현재 보도블럭 기준 이전 보도블럭이 무엇인지를 판별하기 위한 map
+        HashMap map = new HashMap<Character, Character>();
+        map.put('B', 'J');      // 현재 보도블럭이 'B'이면 직전 블럭은 'J'여야함.
+        map.put('O', 'B');      // 현재 보도블럭이 'O'이면 직전 블럭은 'B'여야함.
+        map.put('J', 'O');      // 현재 보도블럭이 'J'이면 직전 블럭은 'O'여야함.
+
+        dp[0] = 0;
+
+        for(int i = 1; i < N; i++) {
+            for(int j = 0; j < i; j++) {
+                // 현재 보도블럭을 기준으로 이전에 밟아야 하는 보도블럭을 확인
+                // 도착가능한 칸이라면
+                if (s.charAt(j) == (char) map.get(s.charAt(i)) && dp[j] != -1) {
+                    // dp[i]가 갱신된 적이 없거나 있더라도 그 값보다 더 작은 에너지로
+                    // i 번째 칸으로 이동할 수 있다면 갱신함.
+                    if(dp[i] == -1 || dp[i] > dp[j] + (i - j) * (i - j)) {
+                        dp[i] = dp[j] + (i - j) * (i - j);
+                    }
+                }
+            }
+        }
+        System.out.println(dp[N - 1]);
+
+    }
+    static class FastReader {
+        BufferedReader br;
+        StringTokenizer st;
+
+        public FastReader() {
+            br = new BufferedReader(new InputStreamReader(System.in));
+        }
+
+        String next() {
+            while(st == null || !st.hasMoreElements()) {
+                try {
+                    st = new StringTokenizer(br.readLine());
+                }
+                catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            return st.nextToken();
+        }
+
+        int nextInt() { return Integer.parseInt(next()); }
+        long nextLong() { return Long.parseLong(next()); }
+        double nextDouble() { return Double.parseDouble(next()); }
+        String nextLine() {
+            String str = "";
+            try {
+                str = br.readLine();
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+            }
+            return str;
+        }
+    }
+}

--- a/dynamic_programming_1/2156/Main.java
+++ b/dynamic_programming_1/2156/Main.java
@@ -1,0 +1,64 @@
+// Authored by : vswngjs
+// Co-authored by : -
+// Link : http://boj.kr/a324587d69454b0b9ecca053e1799831
+import java.util.*;
+import java.io.*;
+public class Main {
+    public static void main(String [] args) {
+        FastReader rd = new FastReader();
+
+        int N = rd.nextInt();
+        int[] grapes = new int[N + 1];
+        int[] dp = new int[N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            grapes[i] = rd.nextInt();
+        }
+
+        dp[1] = grapes[1];
+        if (N > 1) {
+            dp[2] = grapes[1] + grapes[2];
+        }
+        for (int i = 3; i <= N; i++) {
+            dp[i] = Math.max(dp[i - 1], Math.max(dp[i - 2] + grapes[i], dp[i - 3] + grapes[i - 1] + grapes[i]));
+        }
+        System.out.println(dp[N]);
+
+
+
+    }
+    static class FastReader {
+        BufferedReader br;
+        StringTokenizer st;
+
+        public FastReader() {
+            br = new BufferedReader(new InputStreamReader(System.in));
+        }
+
+        String next() {
+            while(st == null || !st.hasMoreElements()) {
+                try {
+                    st = new StringTokenizer(br.readLine());
+                }
+                catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            return st.nextToken();
+        }
+
+        int nextInt() { return Integer.parseInt(next()); }
+        long nextLong() { return Long.parseLong(next()); }
+        double nextDouble() { return Double.parseDouble(next()); }
+        String nextLine() {
+            String str = "";
+            try {
+                str = br.readLine();
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+            }
+            return str;
+        }
+    }
+}


### PR DESCRIPTION
# 백준 문제 솔루션

## 문제 번호

[포도주시식](https://www.acmicpc.net/problem/2156)
[BOJ 거리](https://www.acmicpc.net/problem/12026)



## vswngjs

[vswngjs](https://www.acmicpc.net/user/vswngjs)


## 문제 풀이

2156 
연속으로 놓여 있는 3잔을 모두 마실 수는 없으므로 현재 위치가 i번째 포도주에 있다면 i - 1 번째까지의 누적합, i - 2 번째의 누적합 + i번째 포도주의 양, i -3 번째의 누적합 + i번째 포도주의 양 이렇게 3가지 경우 중 가장 큰 값을 dp 테이블에 업데이트하여 출력하여 해결했습니다

12026
에너지의 양을 최소로 하는 동시에 보도블럭을 밟아야하는 순서가 정해져 있는 문제입니다. 저는 보도블럭의 순서를 Hashmap에 저장하여 체크하는 방식으로 풀어보았습니다. 이 문제는 건널 수 없는 경우 -1을 출력해야하는데 dp table을 -1로 초기화시켜 이를 해결했습니다. dp table이 갱신이 되었더라도 갱신된 값이 비교된 값보다 크다면 재갱신시켜줘야하는 점을 주의해야합니다.