### PR TITLE
[ADD] 2156 Python Solution

### DIFF
--- a/dynamic_programming_1/2156/main.py
+++ b/dynamic_programming_1/2156/main.py
@@ -1,0 +1,19 @@
+# Authored by : wassup37
+# Co-authored by : -
+# Link : http://boj.kr/7ae60e4f30294ef5bf67bbf30ba41ddf
+import sys
+
+read = lambda : sys.stdin.readline().rstrip()
+n = int(read())
+wine = list()
+for _ in range(n):
+    wine.append(int(read()))
+dp = list() # n - 1 인덱스까지의 최댓값을 저장하는 리스트
+dp.append(wine[0])
+if n > 1:
+    dp.append(wine[0] + wine[1])
+if n > 2:
+    dp.append(max(dp[1], dp[0] + wine[2], wine[1] + wine[2]))
+for i in range(3, n):   # 규칙성을 찾아 3가지 case에 대한 최댓값을 삽입한다
+    dp.append(max(dp[i - 1], dp[i - 2] + wine[i], dp[i - 3] + wine[i - 1] + wine[i]))
+print(dp[n - 1])    # 마지막 인덱스까지 확인해서 출력


### PR DESCRIPTION
# 백준 문제 솔루션
## 문제 번호
[포도주 시식](https://www.acmicpc.net/problem/2156)
## 백준 아이디
[wassup37](https://www.acmicpc.net/user/wassup37)
## 문제 풀이
문제 조건에 따르면 포도주 세 잔을 연속해서 선택할 수 없습니다.
이 조건에 따라 최대로 포도주를 최대로 마실 수 있는 포도주 잔을 선택해야 합니다.
풀이를 위해서는 포도주 n번째 잔까지 해서 최대로 마실 수 있는 포도주의 양을 별도의 리스트에 저장해야 합니다. 해당 리스트에 어떤 것을 담아야 하는지는 손으로 직접 그려 보면 파악하기 좋습니다.
첫 번째는 wine[0], 두 번째는 wine[0] + wine[1], 세 번째는 wine[0] + wine[1], wine[1] + wine[2], wine[0] + wine[2] 중에서 최댓값을 선택해서 리스트에 따로 저장합니다. 이런 식으로 계속 파악해보면 규칙성이 보입니다.
dp[i - 1], dp[i - 2] + wine[i], dp[i - 3] + wine[i - 1] + wine[i] 중 최댓값을 찾아 리스트에 넣으면 됩니다.