### PR TITLE
[ADD] 12026 Python Solution

### DIFF
--- a/dynamic_programming_1/12026/main.py
+++ b/dynamic_programming_1/12026/main.py
@@ -1,0 +1,26 @@
+# Authored by : wassup37
+# Co-authored by : -
+# Link : http://boj.kr/bc8f90e9f2c44bbaa6c565dc4ed6b838
+import sys
+
+read = lambda : sys.stdin.readline().rstrip()
+N = int(read())
+block = read()  # 블럭을 string 형태로 받음
+dp = [0] + [sys.maxsize] * N    # 각 블록으로 갈 때의 에너지 최솟값 저장을 위한 dp 배열
+prev = ''
+
+for i in range(1, N):
+    if block[i] == 'B':
+        prev = 'J'
+    elif block[i] == 'O':
+        prev = 'B'
+    else:
+        prev = 'O'  # 이전 문자들 : B -> J, O -> B, J -> O
+    for j in range(i):
+        if block[j] == prev:    # 이전 블럭의 문자를 확인해서
+            dp[i] = min(dp[i], dp[j] + (i - j)**2)  # dp 배열에 각 블럭 별로 최솟값을 저장
+
+if dp[N - 1] == sys.maxsize:
+    print(-1)   # dp 마지막 값이 갱신되지 않으면 도착 못 함
+else:
+    print(dp[N - 1])

--- a/dynamic_programming_1/12026/main.py
+++ b/dynamic_programming_1/12026/main.py
@@ -3,9 +3,11 @@
 # Link : http://boj.kr/bc8f90e9f2c44bbaa6c565dc4ed6b838
 import sys
 
-read = lambda : sys.stdin.readline().rstrip()
-N = int(read())
-block = read()  # 블럭을 string 형태로 받음
+def input():
+    return sys.stdin.readline().rstrip()
+
+N = int(input())
+block = input()  # 블럭을 string 형태로 받음
 dp = [0] + [sys.maxsize] * N    # 각 블록으로 갈 때의 에너지 최솟값 저장을 위한 dp 배열
 prev = ''
 


### PR DESCRIPTION
# 백준 문제 솔루션
## 문제 번호
[BOJ 거리](https://www.acmicpc.net/problem/12026)
## 백준 아이디
[wassup37](https://www.acmicpc.net/user/wassup37)
## 문제 풀이
보도블록을 건널 때 B, O, J, ... 순서로 건너야 합니다.
블록을 건널 때 소모되는 에너지의 최솟값을 구하기 위해 dp를 활용합니다.
dp 배열은 1부터 N-1 인덱스 까지의 블럭을 건널 때 소모되는 에너지 최솟값을 저장합니다. 반복문을 통해 특정 블록에 도착했을 시에 이전 블록 중에서 이전 순서에 와야하는 블록이 있을 때(B -> J, O -> B, J -> O) 소모되는 에너지를 확인해 dp 배열 값을 갱신합니다. 이렇게 dp 배열이 마지막까지 갱신이 된다면 배열의 마지막 인덱스의 값을 출력합니다.